### PR TITLE
Fix for cookies always being set from the server when empty

### DIFF
--- a/src/services/UpvoteService.php
+++ b/src/services/UpvoteService.php
@@ -100,8 +100,8 @@ class UpvoteService extends Component
             $this->anonymousHistory = Json::decode($cookieValue);
         }
 
-        // If no anonymous history
-        if (!$this->anonymousHistory) {
+        // If no anonymous history and cookie oes not already exists
+        if (!$this->anonymousHistory && ! $cookies->has($this->userCookie)) {
             // Initialize anonymous history
             $this->anonymousHistory = [];
             Upvote::$plugin->upvote_vote->saveUserHistoryCookie();

--- a/src/services/UpvoteService.php
+++ b/src/services/UpvoteService.php
@@ -101,7 +101,7 @@ class UpvoteService extends Component
         }
 
         // If no anonymous history and cookie oes not already exists
-        if (!$this->anonymousHistory && ! $cookies->has($this->userCookie)) {
+        if (!$this->anonymousHistory && !$cookies->has($this->userCookie)) {
             // Initialize anonymous history
             $this->anonymousHistory = [];
             Upvote::$plugin->upvote_vote->saveUserHistoryCookie();


### PR DESCRIPTION
Hi @lindseydiloreto,

Just a small fix. I'm running into an issue here.
We're using cloudflare, and cloudflare does not cache if there is a cookie being set. When examining, it turns out that upvote always sets the cookie when there is no history available. 

Even though there is already a cookie with empty history, upvote replaces it with another empty cookie. Meaning every request gets an empty (meaning once decoded an empty array) cookie from upvote.

This just checks if the cookie is empty and does not exists.