### PR TITLE
Fix warning - Element query executed before Craft is fully initialized.

### DIFF
--- a/src/Upvote.php
+++ b/src/Upvote.php
@@ -18,6 +18,7 @@ use craft\base\Plugin;
 use craft\events\RegisterElementTableAttributesEvent;
 use craft\events\SetElementTableAttributeHtmlEvent;
 use craft\services\Plugins;
+use craft\web\Application;
 use craft\web\twig\variables\CraftVariable;
 use doublesecretagency\upvote\models\Settings;
 use doublesecretagency\upvote\services\Query;
@@ -93,10 +94,8 @@ class Upvote extends Plugin
         $this->upvote->getAnonymousHistory();
 
         // Load logged-in user history (if relevant)
-        Event::on(
-            Plugins::class,
-            Plugins::EVENT_AFTER_LOAD_PLUGINS,
-            function () {
+        Craft::$app->on(
+            Application::EVENT_INIT, function() {
                 // If no current user
                 if (!Craft::$app->user->getIdentity()) {
                     return;


### PR DESCRIPTION
In Craft 4, there's a warning raised whenever element queries are executed before Craft is ready.

This stems from using `Plugins::EVENT_AFTER_LOAD_PLUGINS` to run certain code, instead of `Application::EVENT_INIT`. It usually only involves calling `Craft::$app->user->getIdentity()` to trigger this warning. It's not an element query in Upvote specifically, but in the user element query. It's just that fetching the current user is called too early.

Full stack trace below.

```
warning craft\elements\db\ElementQuery::prepare Element query executed before Craft is fully initialized.
Stack trace:
#0 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/db/QueryBuilder.php(227): craft\elements\db\ElementQuery->prepare()
#1 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/db/Query.php(157): yii\db\QueryBuilder->build()
#2 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/db/Query.php(287): yii\db\Query->createCommand()
#3 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/db/Query.php(276): yii\db\Query->one()
#4 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/elements/db/ElementQuery.php(1580): craft\db\Query->one()
#5 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/elements/User.php(519): craft\elements\db\ElementQuery->one()
#6 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/web/User.php(698): craft\elements\User::findIdentity()
#7 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/web/User.php(500): yii\web\User->renewAuthStatus()
#8 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/web/User.php(199): craft\web\User->renewAuthStatus()
#9 /Users/joshcrawford/public_html/site/vendor/doublesecretagency/craft-upvote/src/Upvote.php(101): yii\web\User->getIdentity()
#10 doublesecretagency\upvote\Upvote->doublesecretagency\upvote\{closure}()
#11 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/base/Event.php(312): call_user_func()
#12 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/base/Component.php(642): yii\base\Event::trigger()
#13 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/services/Plugins.php(275): yii\base\Component->trigger()
#14 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/base/ApplicationTrait.php(1554): craft\services\Plugins->loadPlugins()
#15 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/web/Application.php(106): craft\web\Application->_postInit()
#16 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/base/BaseObject.php(109): craft\web\Application->init()
#17 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/base/Application.php(204): yii\base\BaseObject->__construct()
#18 yii\base\Application->__construct()
#19 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/di/Container.php(419): ReflectionClass->newInstanceArgs()
#20 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/di/Container.php(170): yii\di\Container->build()
#21 /Users/joshcrawford/public_html/site/vendor/yiisoft/yii2/BaseYii.php(365): yii\di\Container->get()
#22 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/src/Craft.php(54): yii\BaseYii::createObject()
#23 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/bootstrap/bootstrap.php(252): Craft::createObject()
#24 /Users/joshcrawford/public_html/site/vendor/craftcms/cms/bootstrap/web.php(40): require()
#25 /Users/joshcrawford/public_html/site/public_html/index.php(25): require()
```