### PR TITLE
Improve performance of sort method

### DIFF
--- a/src/services/Query.php
+++ b/src/services/Query.php
@@ -318,7 +318,7 @@ class Query extends Component
         $elementIds = (new CraftQuery())
             ->select('[[elements.id]]')
             ->from('{{%elements}} elements')
-	          ->where(['[[elements.type]]' => $query->elementType])
+            ->where(['[[elements.type]]' => $query->elementType])
             ->leftJoin(['subquery' => $subquery], '[[elements.id]] = [[subquery.elementId]]')
             ->orderBy([new Expression($queryOrder)]);
 				

--- a/src/services/Query.php
+++ b/src/services/Query.php
@@ -280,10 +280,10 @@ class Query extends Component
             return [];
         }
 				
-				if($useQueryIds) {
-					$queryClone = clone $query;
-					$ids = $queryClone->ids();
-				}
+        if($useQueryIds) {
+            $queryClone = clone $query;
+            $ids = $queryClone->ids();
+        }
 
         // Adjust conditions based on whether a key was provided
         if (null === $key) {

--- a/src/services/Query.php
+++ b/src/services/Query.php
@@ -251,12 +251,11 @@ class Query extends Component
      *
      * @param ElementQuery $query
      * @param null|string $key
-     * @param bool $useQueryIds
      */
-    public function orderByTally(ElementQuery $query, ?string $key = null, ?bool $useQueryIds = true): void
+    public function orderByTally(ElementQuery $query, ?string $key = null): void
     {
         // Get and sort element IDs
-        $elementIds = $this->_elementIdsByTally($key, $query, $useQueryIds);
+        $elementIds = $this->_elementIdsByTally($key, $query);
 
         // If no element IDs, bail
         if (!$elementIds) {
@@ -276,16 +275,11 @@ class Query extends Component
      * @param bool $useQueryIds
      * @return array
      */
-    private function _elementIdsByTally(?string $key, ElementQuery $query, bool $useQueryIds): array
+    private function _elementIdsByTally(?string $key, ElementQuery $query): array
     {
         // If key isn't valid, bail with empty array
         if (!Upvote::$plugin->upvote->validKey($key)) {
             return [];
-        }
-				
-        if($useQueryIds) {
-            $queryClone = clone $query;
-            $ids = $queryClone->ids();
         }
 
         // Adjust conditions based on whether a key was provided
@@ -323,14 +317,11 @@ class Query extends Component
             ->from('{{%elements}} elements')
             ->where(['[[elements.type]]' => $query->elementType])
             ->leftJoin(['subquery' => $subquery], '[[elements.id]] = [[subquery.elementId]]')
-            ->orderBy([new Expression($queryOrder)]);
-				
-        if($useQueryIds) {
-            $elementIds->andWhere(['[[elements.id]]' => $ids]);
-        }
+            ->orderBy([new Expression($queryOrder)])
+            ->column();
 	
         // Return element IDs in order of highest voted
-        return $elementIds->column();
+        return $elementIds;
     }
 
 }

--- a/src/services/Query.php
+++ b/src/services/Query.php
@@ -251,6 +251,7 @@ class Query extends Component
      *
      * @param ElementQuery $query
      * @param null|string $key
+     * @param bool $useQueryIds
      */
     public function orderByTally(ElementQuery $query, ?string $key = null, ?bool $useQueryIds = true): void
     {
@@ -271,6 +272,8 @@ class Query extends Component
      * Get and sort element IDs.
      *
      * @param null|string $key
+     * @param ElementQuery $query
+     * @param bool $useQueryIds
      * @return array
      */
     private function _elementIdsByTally(?string $key, ElementQuery $query, bool $useQueryIds): array

--- a/src/variables/UpvoteVariable.php
+++ b/src/variables/UpvoteVariable.php
@@ -461,9 +461,9 @@ class UpvoteVariable
      * @param ElementQuery $elements
      * @param null|string $key
      */
-    public function sort(ElementQuery $elements, ?string $key = null): void
+    public function sort(ElementQuery $elements, ?string $key = null, ?bool $useQueryIds = true): void
     {
-        Upvote::$plugin->upvote_query->orderByTally($elements, $key);
+        Upvote::$plugin->upvote_query->orderByTally($elements, $key, $useQueryIds);
     }
 
     /**

--- a/src/variables/UpvoteVariable.php
+++ b/src/variables/UpvoteVariable.php
@@ -460,6 +460,7 @@ class UpvoteVariable
      *
      * @param ElementQuery $elements
      * @param null|string $key
+     * @param bool $useQueryIds
      */
     public function sort(ElementQuery $elements, ?string $key = null, ?bool $useQueryIds = true): void
     {

--- a/src/variables/UpvoteVariable.php
+++ b/src/variables/UpvoteVariable.php
@@ -460,11 +460,10 @@ class UpvoteVariable
      *
      * @param ElementQuery $elements
      * @param null|string $key
-     * @param bool $useQueryIds
      */
-    public function sort(ElementQuery $elements, ?string $key = null, ?bool $useQueryIds = true): void
+    public function sort(ElementQuery $elements, ?string $key = null): void
     {
-        Upvote::$plugin->upvote_query->orderByTally($elements, $key, $useQueryIds);
+        Upvote::$plugin->upvote_query->orderByTally($elements, $key);
     }
 
     /**


### PR DESCRIPTION
- update `elementIdsByTally()` method query to improve performance by using query's type to filter possible results.
- add a third parameter to the `craft.upvote.sort()` template variable that controls whether the `elementIdsByTally()` method should execute the primary query using `->ids()` to further filter the possible results from that method.

If approved, the [documentation](https://plugins.doublesecretagency.com/upvote/sort-by-highest-voted/) will need updated to reflect the optional third parameter. The parameter defaults to `true` as it should generally be beneficial but users might want to disable it if they have a query that could return a really large number of elements or if they are experiencing poor performance from sorting.

resolves #40 